### PR TITLE
add white-space nowrap to contact h2

### DIFF
--- a/src/Components/Contact.js
+++ b/src/Components/Contact.js
@@ -113,6 +113,11 @@ class _Contact extends Component {
 }
 
 const Contact = styled(_Contact)`
+  /* prevents edge bug where () break to separate line */
+  h2 {
+    white-space: nowrap;
+  }
+
   input:not([type="submit"]),
   textarea {
     background-color: ${props => props.theme.color.contrastMild};


### PR DESCRIPTION
Fixes #16 by adding `white-space: nowrap` to `h2` on Contact page (causes bugs if added to headings generally).

[Edge/IE break on parentheses](https://stackoverflow.com/questions/2712716/non-breaking-parentheses)

![screenshot 2019-01-23 07 08 16](https://user-images.githubusercontent.com/19560286/51615851-b08ac180-1edd-11e9-9cf6-8c35367b5cac.png)
