### PR TITLE
Fix form focus

### DIFF
--- a/src/Components/Contact.js
+++ b/src/Components/Contact.js
@@ -21,19 +21,21 @@ class _Contact extends Component {
     document.querySelector('nav').classList.remove('menuActive');
 
     // form listener
-    document.querySelector('form').addEventListener('keyup', () => {
-      let count=0;
-      document.querySelectorAll('.required').forEach(field => {
-        if (field.value !== '') {
-          count += 1;
-          if (count === document.querySelectorAll('.required').length) {
-            document.querySelector('#submit').disabled = false;
-            return;
-          } else {
-            document.querySelector('#submit').disabled = true;
+    document.querySelector('form').addEventListener('keyup', (event) => {
+      if (event.target.classList.contains('required')) {
+        let count=0;
+        document.querySelectorAll('.required').forEach(field => {
+          if (field.value !== '') {
+            count += 1;
+            if (count >= document.querySelectorAll('.required').length) {
+              document.querySelector('#submit').disabled = false;
+              return;
+            } else {
+              document.querySelector('#submit').disabled = true;
+            }
           }
-        }
-      });
+        });
+      }
     });
   }
 

--- a/src/Components/Contact.js
+++ b/src/Components/Contact.js
@@ -22,19 +22,23 @@ class _Contact extends Component {
 
     // form listener
     document.querySelector('form').addEventListener('keyup', (event) => {
+      // should only fire on required form fields
+      // prevents focus bug when navigating w/ keyboard
       if (event.target.classList.contains('required')) {
-        let count=0;
-        document.querySelectorAll('.required').forEach(field => {
-          if (field.value !== '') {
+        
+        const requiredFields = Array.from(document.querySelectorAll('.required'));
+        const submitButton = document.querySelector('#submit');
+
+        requiredFields.reduce((count, field) => {
+          if (field.value) {
             count += 1;
-            if (count >= document.querySelectorAll('.required').length) {
-              document.querySelector('#submit').disabled = false;
-              return;
-            } else {
-              document.querySelector('#submit').disabled = true;
-            }
+            count >= requiredFields.length
+              ? submitButton.disabled = false
+              : submitButton.disabled = true;
+            return count;
           }
-        });
+          return null;
+        }, 0);
       }
     });
   }


### PR DESCRIPTION
Applies logic in event listener only for _required form fields_.

Fixes accessibility bug where keyboard navigation caused `keyup` listener to fire when tabbing to `submit` button, causing `submit` to lose focus. Refactors listener as well.

Fixes #12.