### PR TITLE
Fix Edge dark mode toggle

### DIFF
--- a/src/Components/NavList.js
+++ b/src/Components/NavList.js
@@ -141,7 +141,7 @@ const StyledNavList = styled(NavList)`
 
   #darkMode:hover span {
     @media (min-width: 768px) {
-      width: fit-content;
+      width: auto;
       height: 1.5rem;
       padding: .5rem;
       top: 3.5rem;


### PR DESCRIPTION
Changes dark mode button span `width` from `fit-content` to `auto`. Fixes #15.

![screenshot 2019-01-26 06 29 57](https://user-images.githubusercontent.com/19560286/51788559-1bcdd100-2134-11e9-8921-b8ab5f3b17eb.png)
