### PR TITLE
change laptop max-width from % to vw (FF mobile fix)

### DIFF
--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -107,7 +107,7 @@ const Home = styled(_Home)`
 
   #laptop {
     height: auto;
-    max-width: 100%;
+    max-width: 100vw;
   }
 
   #laptop-monitor {


### PR DESCRIPTION
Changes laptop svg's `max-width: 100%` to `max-width: 100vw`. Fixes #29.

![screenshot 2019-02-05 06 56 55](https://user-images.githubusercontent.com/19560286/52282462-534b3300-2915-11e9-9402-aa55ebfb5269.png)
