### PR TITLE
Fix codepen border

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -352,13 +352,20 @@ nav a:focus {
   animation: fadein .5s 2.5s forwards;
 }
 
-#animations .codepen,
 #animations .cp_embed_wrapper {
+  height: 352px;
+}
+
+#animations .codepen {
   height: 350px;
 }
 
-#fizzbuzz .codepen,
+
 #fizzbuzz .cp_embed_wrapper {
+  height: 277px;
+}
+
+#fizzbuzz .codepen {
   height: 275px;
 }
 

--- a/src/Components/Main.js
+++ b/src/Components/Main.js
@@ -86,12 +86,14 @@ const Main = styled(_Main)`
     margin-top: 0;
   }
 
-  #name {
-    filter: ${props => props.darkMode ? 'invert(1) hue-rotate(-180deg) brightness(2.5)' : 'none'};
-  }
-
+  /* resume pie chart img */
   #skills-graph {
     filter: ${props => props.darkMode ? 'invert(1)' : 'none'};
+  }
+
+  /* codepen embed */
+  .cp_embed_wrapper {
+    border: 1px solid ${props => props.theme.color.gray} !important;
   }
 `;
 


### PR DESCRIPTION
Adds gray border in both light/dark modes for all codepen embeds (can't modify iframe or its contents directly). Distinguishes dark bkgd codepens in dark mode.

#### Light Mode

![screenshot 2019-02-17 07 35 08](https://user-images.githubusercontent.com/19560286/52915290-e32e9c80-3286-11e9-9fea-8b6b05d511b4.png)

#### Dark Mode

![screenshot 2019-02-17 07 35 17](https://user-images.githubusercontent.com/19560286/52915291-e3c73300-3286-11e9-8f7f-770e45fa9f9e.png)